### PR TITLE
Split Travis install script into separate lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: c
 install:
-  - git clone --depth 1 git://github.com/Araq/Nim.git; cd Nim; git clone --depth 1 git://github.com/nim-lang/csources; cd csources; sh build.sh; cd ../..
+  - git clone --depth 1 git://github.com/Araq/Nim.git
+  - cd Nim
+  - git clone --depth 1 git://github.com/nim-lang/csources
+  - cd csources
+  - sh build.sh
+  - cd ../..
 before_script:
   - export PATH=./Nim/bin:$PATH
 script: make


### PR DESCRIPTION
to make it easier to read and debug

As [Travis CI: Customizing the Build – Customizing the Installation Step](http://docs.travis-ci.com/user/customizing-the-build/#Customizing-the-Installation-Step) shows, you can specify multiple shell commands as a YAML list; you don’t have to join the commands with semicolons.
